### PR TITLE
chore: update dependencies for Solverz 0.8.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,6 +20,6 @@ sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
 sphinx-reredirects
 chardet
-Solverz>=0.7.2
-SolMuseum>=0.1.4
+Solverz>=0.8.0
+SolMuseum>=0.1.5
 SolUtil @ git+https://github.com/rzyu45/SolUtil@master

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,8 @@ Here presents a collection of modelling and numerical solution examples based on
 
    This cookbook is tested against the following dependency versions:
 
-   - **Solverz** >= 0.7.2
-   - **SolMuseum** >= 0.1.4
+   - **Solverz** >= 0.8.0
+   - **SolMuseum** >= 0.1.5
    - **SolUtil** (latest master)
 
 


### PR DESCRIPTION
## Summary
- Update Solverz dependency to >=0.8.0 for Mat_Mul matrix calculus support
- Update SolMuseum dependency to >=0.1.5 for entry_points plugin discovery

## Test plan
- [ ] CI passes on Windows
- [ ] test_pf_matmul passes with Solverz 0.8.0 Mat_Mul Jacobian
- [ ] test_ies passes with SolMuseum 0.1.5 entry_points

🤖 Generated with [Claude Code](https://claude.com/claude-code)