### PR TITLE
docs(pf): add LoopEqn vs for-loop power-flow comparison and test

### DIFF
--- a/docs/source/ae/pf/pf.md
+++ b/docs/source/ae/pf/pf.md
@@ -260,6 +260,86 @@ Every `Mat_Mul(A, v)` placeholder is classified at code-gen time. A placeholder 
 The cold-compile cost for the for-loop form (~47 s on M4) matches the "hundreds of seconds" figure quoted for the older Ryzen 5800H laptop earlier in this chapter. The *absolute* number is sensitive to CPU single-thread performance, but the **ratio** between the two formulations (≈17×) is driven almost entirely by the number of `@njit` kernels the code generator emits, which is a property of the formulation, not the hardware.
 ```
 
+## Compact polar power flow with `LoopEqn`
+
+The `Mat_Mul` formulation above removes the for-loops by switching to rectangular ($e$, $f$) coordinates. Since version 0.9.0, Solverz offers a second way to remove the for-loops that **keeps the polar trigonometric formulation intact**: the `LoopEqn` template. Instead of writing one scalar `Eqn` per bus inside a Python `for` loop, we declare a single symbolic loop whose outer index ranges over a `Set` of buses and whose body sums over the neighbour `Set`:
+
+```{math}
+\left\{
+\begin{aligned}
+&P_h:\quad v_h\sum_{k}v_k\,g_{hk}\cos\theta_{hk}+v_h\sum_{k}v_k\,b_{hk}\sin\theta_{hk}+p^d_h-p^g_h=0,\quad h\in\mathbb{B}_\text{pv,pq}\\
+&Q_h:\quad v_h\sum_{k}v_k\,g_{hk}\sin\theta_{hk}-v_h\sum_{k}v_k\,b_{hk}\cos\theta_{hk}+q^d_h-q^g_h=0,\quad h\in\mathbb{B}_\text{pq}
+\end{aligned}
+\right.
+```
+
+Here the outer index $h$ and the summation index $k$ are *symbolic* loop indices, not Python loop counters. A `Set` names a subset of bus indices; `Set.idx(...)` produces a bounded loop index; `Sum(expr, k)` is the symbolic neighbour sum; and `LoopEqn(name, outer_index=h, body=..., model=m)` expands at code-generation time into a compact loop kernel rather than `nb` unrolled scalar equations. The state is the flat `Vm_full` / `Va_full` over every bus, and two tiny `LoopEqn` pins fix the ref/pv voltages to their known values, squaring the system.
+
+```{literalinclude} src/pf_mdl_loopeqn.py
+```
+
+```{note}
+Each `LoopEqn` body reads like the math it implements. The sparse `Gbus[h, k]` / `Bbus[h, k]` access compiles to a CSR row walk over bus `h`, so the inner `Sum` touches only the actual neighbours of `h` rather than all `nb` buses. See the canonical [LoopEqn walkthrough](https://docs.solverz.org/loopeqn.html) for the full template syntax.
+```
+
+## Performance comparison: `LoopEqn` vs. for-loop
+
+Where the `Mat_Mul` comparison above changes coordinates, this comparison isolates the *loop-expression* cost alone: both models are in the **same polar coordinates** and solve the identical `case30` power flow. The only difference is whether the per-bus summations are unrolled into 53 scalar `Eqn`s by a Python loop ([`src/pf_mdl.py`](src/pf_mdl.py)) or expressed as 4 symbolic `LoopEqn` families ([`src/pf_mdl_loopeqn.py`](src/pf_mdl_loopeqn.py)). The benchmark script is [`src/bench_pf_loopeqn_vs_polar.py`](src/bench_pf_loopeqn_vs_polar.py):
+
+```bash
+cd docs/source/ae/pf/src
+python bench_pf_loopeqn_vs_polar.py
+```
+
+```{note}
+`made_numerical` (the inline lambdify path) does **not** support `LoopEqn` — `LoopEqn` is designed for the Numba-JIT module-printer path. Every phase below is therefore measured on the `module_printer(..., jit=True)` pipeline, which is the production path Solverz recommends anyway.
+```
+
+### Benchmark environment
+
+Measured on the same machine as the `Mat_Mul` comparison: 2025 MacBook Air, Apple M4, macOS 26.5, Python 3.11.13, `numpy==2.3.5`, `scipy==1.16.3`, `numba==0.65.0`, `sympy==1.13.3`, and Solverz 0.9.x (the LoopEqn release). Each per-call number is 10 warm-up calls followed by 2000 timed iterations; the cold-compile measurement runs in a fresh subprocess with `__pycache__` and Numba `.nbi`/`.nbc` caches wiped beforehand. The numbers below are representative medians of three consecutive runs.
+
+| Phase                                            |    for-loop (polar) |     LoopEqn (polar) |  LoopEqn wins by |
+| :----------------------------------------------- | ------------------: | ------------------: | ---------------: |
+| **Modelling** — `Model() → create_instance()`    |            ≈ 1.4 s  |            ≈ 0.09 s |             ~15× |
+| **Compilation** — module render (`jit=True`)      |            ≈ 0.6 s  |           ≈ 0.014 s |             ~43× |
+| **Compilation** — `@njit` kernels emitted         |               416  |                 12 |             ~35× |
+| **Compilation** — module cold import + JIT        |             ≈ 45 s  |            ≈ 2.5 s |             ~18× |
+| **Computation** — module hot **F** (per call)     |           ≈ 1.05 µs |           ≈ 2.35 µs | 0.45× *(loses)* |
+| **Computation** — module hot **J** (per call)     |             ≈ 55 µs |             ≈ 36 µs |             ~1.5× |
+| **Computation** — Newton-Raphson end-to-end       |            ≈ 0.33 ms |           ≈ 0.20 ms |             ~1.6× |
+
+Shapes: the polar for-loop form has **53 unknowns / 53 scalar `Eqn`s** (`Va` at PV+PQ buses, `Vm` at PQ buses); the LoopEqn form has **60 unknowns / 4 equation families** — `Vm_full` and `Va_full` over all 30 buses, with P balance over PV+PQ, Q balance over PQ, and two pin families fixing the ref/pv voltages, for 60 scalar rows.
+
+### Modelling cost
+
+`Model()` construction plus `create_instance()` is **~15× faster** with `LoopEqn` (≈ 0.09 s vs ≈ 1.4 s). The for-loop form materialises 53 fully-expanded scalar trigonometric expressions in Python, each a sum of up to `nb` terms, and `create_instance()` must traverse all of them to build the symbolic IR. The LoopEqn form carries 4 compact loop templates instead, so the symbolic layer never sees the unrolled expansion.
+
+### Compilation cost
+
+This is the headline. `LoopEqn` emits **12** `@njit` kernels where the for-loop form emits **416**, and the cold compile, render, and model-build times all scale with that count:
+
+- **for-loop** — 1 dispatcher `inner_F` + **53** per-bus `inner_F{i}` + 1 dispatcher `inner_J` + **361** per-non-zero `inner_J{k}` = **416** Numba kernels. Each kernel is a cheap scalar expression, but the fixed per-kernel overhead (LLVM instantiation, symbol table, cache write) dominates the ~45 s cold compile.
+- **LoopEqn** — 1 dispatcher `inner_F` + **4** per-family loop kernels (`inner_F0..3`, one per `LoopEqn`) + 1 dispatcher `inner_J` delegating to **4** vectorised `_sz_loop_jac_kernel_N` kernels (each scatters one equation family into precomputed `_sz_loop_jac_row_N` / `_sz_loop_jac_col_N` index arrays) + **2** `_sz_csr_*_point` CSR-lookup helpers = **12** kernels. Cold compile (~2.5 s) is dominated by Numba startup, not per-kernel work.
+
+### Computation cost
+
+At runtime, `LoopEqn` and `Mat_Mul` part ways:
+
+- **Hot F is ~2.2× slower** (≈ 2.35 µs vs ≈ 1.05 µs). The for-loop's 53 scalar `inner_F{i}` bodies are inlined by LLVM into one straight-line `inner_F` — a single Python→Numba crossing with no data-dependent indexing. The LoopEqn `inner_F` runs 4 loop kernels whose inner `Sum` walks the CSR row of bus `h` (`_sz_csr_Gbus_indptr[h] : _sz_csr_Gbus_indptr[h+1]`); the gather indirection plus loop overhead costs the extra ~1.3 µs on `case30`. This is the same structural regression `Mat_Mul` pays on small networks.
+- **Hot J is ~1.5× faster** (≈ 36 µs vs ≈ 55 µs) — the opposite of hot F. The for-loop form dispatches **361 tiny per-non-zero kernels**, each computing one Jacobian entry and paying its own call overhead; LoopEqn assembles the whole Jacobian through **4** vectorised `_sz_loop_jac_kernel_N` kernels, one per equation family. Far fewer, larger kernels win once per-call dispatch dominates, which it does for a several-hundred-entry sparse Jacobian.
+- **Newton-Raphson end-to-end is ~1.6× faster** (≈ 0.20 ms vs ≈ 0.33 ms). Each Newton step is one F + one J + one sparse solve, and J dominates the per-step cost, so the faster J carries the iteration. The step counts differ slightly (2 for LoopEqn, 3 for the for-loop) because the perturbed flat start is parameterised over the full vs the reduced state, so this end-to-end number is indicative rather than a strictly equi-perturbed comparison.
+
+### Which formulation should I use?
+
+`LoopEqn` is the better default for polar power flow whenever you iterate on the model or solve with a Newton method:
+
+1. **You want to stay in polar coordinates.** Unlike `Mat_Mul`, which requires the rectangular $e$/$f$ rewrite, `LoopEqn` keeps the trigonometric formula the textbook uses, so the code reads like the math.
+2. **You rebuild the module.** The ~18× cold-compile and ~43× render savings are paid on every rebuild — the difference between an interactive and an unusable edit loop.
+3. **Your loop calls a Jacobian** (every Newton/NR solve does). The faster J and faster end-to-end NR make `LoopEqn` at least as fast as the for-loop at solve time on `case30`, with the compile-time savings on top.
+
+The one workload where the for-loop form still wins is a hot loop of **pure F evaluations** (no Jacobian) on a small network with the module compiled once and reused for millions of calls — the same narrow case as the `Mat_Mul` regression above.
+
 ## Ill-conditioned Power flow
 
 The Newton method sometimes fails because it is not robust enough. We view this cases as having ill-conditioned initial settings. In this cases, we can use some more robust methods, such as the semi-implicit continuous Newton method (SICNM)[^sicnm] provided by Solverz. Shown below is an illustrative example of ill-conditioned power flow. The Newton failed while the SICNM easily converged. 

--- a/docs/source/ae/pf/src/bench_pf_loopeqn_vs_polar.py
+++ b/docs/source/ae/pf/src/bench_pf_loopeqn_vs_polar.py
@@ -1,0 +1,337 @@
+"""Benchmark ``LoopEqn`` vs the traditional for-loop power-flow
+formulation on case30.
+
+Both formulations stay in **polar** coordinates and solve the same
+case30 power flow. The only difference is how the per-bus power-balance
+summations are handed to Solverz:
+
+  * **for-loop** (``pf_mdl.py``) — Python ``for`` loops expand each
+    bus's power balance into one scalar ``Eqn``. case30 produces 53
+    scalar ``Eqn``s (P at pv+pq, Q at pq).
+  * **LoopEqn** (``pf_mdl_loopeqn.py``) — one symbolic ``LoopEqn`` per
+    balance family iterates the outer bus index over a ``Set`` and sums
+    over the neighbour ``Set``. case30 produces 4 equation families
+    (P_eqn, Q_eqn, Vm_pin, Va_pin), 60 scalar rows after pinning the
+    ref/pv buses on the flat ``Vm_full`` / ``Va_full`` state.
+
+``made_numerical`` (the inline lambdify path) does **not** support
+LoopEqn — it is designed for the Numba-JIT module-printer path (see
+Solverz issue #132). The comparison is therefore module-path-only:
+every phase below runs on the ``module_printer(..., jit=True)``
+pipeline, which is the production path anyway.
+
+Phases measured (mapped to the three axes the cookbook reports):
+
+  modelling   1. Model build + ``create_instance``
+  compilation 2. Module render (``module_printer(..., jit=True).render``)
+              3. ``@njit`` kernel count (every ``@njit`` in num_func.py,
+                 not just the ``inner_*`` ones)
+              4. Module cold import + JIT compile (fresh subprocess,
+                 ``__pycache__`` and Numba ``.nbi``/``.nbc`` wiped; the
+                 rendered ``__init__`` warms F/J during import, so the
+                 import time IS the cold-compile cost)
+  computation 5. Module hot F / J (steady-state per-call time)
+              6. Newton-Raphson end-to-end (``nr_method``)
+
+Prints a summary table at the end. Re-run on any hardware with::
+
+    cd docs/source/ae/pf/src
+    python bench_pf_loopeqn_vs_polar.py
+"""
+from __future__ import annotations
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+# Persistent output dir for the rendered modules (left on disk so the
+# numbers are inspectable; the path is printed at the end).
+OUT_ROOT = tempfile.mkdtemp(prefix="bench_pf_loopeqn_")
+
+CASE_DATA_DIR = os.path.join(HERE, 'test_pf_jac')
+
+
+# ---------------------------------------------------------------------------
+# Model builders. Each returns ``(spf, y0)`` so phase 1 times the whole
+# "Model() + equations + create_instance()" modelling cost identically.
+# ---------------------------------------------------------------------------
+
+def build_polar():
+    """Traditional for-loop polar model (identical to ``pf_mdl.py``)."""
+    # Re-use the canonical polar builder that already backs the
+    # Mat_Mul-vs-polar comparison so the two benchmarks measure the
+    # exact same for-loop model.
+    from bench_pf_matmul_vs_polar import build_polar as _bp
+    return _bp()
+
+
+def build_loopeqn():
+    """LoopEqn polar model (from ``pf_mdl_loopeqn.py``)."""
+    from pf_mdl_loopeqn import build_loopeqn_pf_model
+    m = build_loopeqn_pf_model(datadir=CASE_DATA_DIR)
+    return m.create_instance()
+
+
+# ---------------------------------------------------------------------------
+# Timing helpers.
+# ---------------------------------------------------------------------------
+
+def _timed(fn, *args, **kwargs):
+    t0 = time.perf_counter()
+    out = fn(*args, **kwargs)
+    t1 = time.perf_counter()
+    return out, t1 - t0
+
+
+def _clean_numba_cache_for_module(module_dir):
+    """Delete ``__pycache__`` and ``.nbi``/``.nbc`` so the next import
+    triggers a cold Numba compile."""
+    for root, dirs, files in os.walk(module_dir):
+        for d in list(dirs):
+            if d == '__pycache__':
+                shutil.rmtree(os.path.join(root, d), ignore_errors=True)
+                dirs.remove(d)
+        for f in files:
+            if f.endswith('.nbi') or f.endswith('.nbc'):
+                try:
+                    os.remove(os.path.join(root, f))
+                except OSError:
+                    pass
+
+
+def _count_njit_kernels(num_func_path):
+    """Count every ``@njit``-decorated function in num_func.py.
+
+    This is the honest compile-surface metric: it counts ALL kernels
+    Numba must compile, not just the ``inner_*`` ones. The for-loop
+    module emits only ``inner_F*`` / ``inner_J*`` kernels, but the
+    LoopEqn module also emits ``_sz_loop_jac_kernel_N`` (per-family
+    Jacobian assembly) and ``_sz_csr_*_point`` (CSR element lookup)
+    helpers, each of which is ``@njit(cache=True)`` and pays the same
+    per-kernel compile cost. Counting only ``inner_*`` would compare a
+    full count on one side against a filtered subset on the other.
+    """
+    if not os.path.exists(num_func_path):
+        return None
+    with open(num_func_path, 'r') as f:
+        text = f.read()
+    return len(re.findall(r'^@njit', text, flags=re.MULTILINE))
+
+
+# ---------------------------------------------------------------------------
+# Phase runners.
+# ---------------------------------------------------------------------------
+
+def run_modeling_phases(kind, build_fn):
+    """Phases 1-3 in-process: build + create_instance, render, njit count."""
+    from Solverz import module_printer
+
+    (spf, y0), t_build = _timed(build_fn)
+
+    out_dir = os.path.join(OUT_ROOT, kind)
+    os.makedirs(out_dir, exist_ok=True)
+    mod_name = f'pf_{kind}_mod'
+    _, t_render = _timed(lambda: module_printer(
+        spf, y0, mod_name, directory=out_dir, jit=True).render())
+
+    num_func_path = os.path.join(out_dir, mod_name, 'num_func.py')
+    n_njit = _count_njit_kernels(num_func_path)
+
+    return {
+        'build': t_build,
+        'render': t_render,
+        'njit_count': n_njit,
+        'module_dir': out_dir,
+        'mod_name': mod_name,
+        'n_eqn_families': len(spf.EQNs),
+        'eqn_size': spf.eqn_size,
+    }
+
+
+def run_subprocess_phases(kind, out_dir, mod_name):
+    """Phases 4-6 in a fresh subprocess with the Numba cache wiped:
+    cold import+JIT, hot F/J, NR end-to-end."""
+    _clean_numba_cache_for_module(out_dir)
+
+    driver = f'''
+import os, sys, time, gc, copy
+sys.path.insert(0, {out_dir!r})
+gc.disable()
+
+# --- Phase 4: cold import + JIT compile ---
+# The rendered __init__ already calls F/J once during import to warm
+# the Numba caches, so the import time IS the cold-compile cost (this
+# matches how bench_pf_matmul_vs_polar.py reports COLD).
+t0 = time.perf_counter()
+import {mod_name} as M
+t_cold = time.perf_counter() - t0
+
+mdl = M.mdl
+y = M.y
+p = mdl.p
+
+# --- Phase 5: hot F / J (steady state) ---
+def hot(call, *args, n_warm=10, n_meas=2000):
+    for _ in range(n_warm):
+        call(*args)
+    t0 = time.perf_counter()
+    for _ in range(n_meas):
+        call(*args)
+    t1 = time.perf_counter()
+    return (t1 - t0) / n_meas
+
+t_F = hot(mdl.F, y, p)
+t_J = hot(mdl.J, y, p)
+
+# --- Phase 6: Newton-Raphson end-to-end ---
+# Perturb the (already-converged) stored y so NR actually iterates.
+# NOTE: the two models parameterise their state differently — the
+# for-loop model has 53 free vars (Vm at pq, Va at pv+pq) while the
+# LoopEqn model has 60 (full Vm/Va with ref/pv pinned). Each model is
+# perturbed only on its OWN vars below, so the perturbation scope (and
+# hence the NR step count) differs. Read the NR-end-to-end row together
+# with the printed step counts, not as a pure per-iteration comparison.
+from Solverz import nr_method
+
+def _perturbed(yfresh):
+    y2 = type(yfresh)(yfresh.a, yfresh.array.copy())
+    for name, dv in (('Vm', 0.05), ('Va', 0.02),
+                     ('Vm_full', 0.05), ('Va_full', 0.02)):
+        if name in y2.var_list:
+            y2[name] = y2[name] + dv
+    return y2
+
+nr_method(mdl, _perturbed(M.y))           # warm
+t0 = time.perf_counter()
+sol = nr_method(mdl, _perturbed(M.y))
+t_nr = time.perf_counter() - t0
+
+print("COLD", repr(t_cold))
+print("HOT_F", repr(t_F))
+print("HOT_J", repr(t_J))
+print("NR", repr(t_nr))
+print("NR_OK", int(bool(sol.stats.succeed)))
+print("NR_ITS", int(sol.stats.nstep))
+'''
+    # Point Numba at a fresh cache dir under OUT_ROOT (itself a per-run
+    # mkdtemp), so the cold-compile measurement can never be served a
+    # stale cache from a previous run.
+    nb_cache = os.path.join(OUT_ROOT, 'nbcache_' + kind)
+    os.makedirs(nb_cache, exist_ok=True)
+    proc = subprocess.run(
+        [sys.executable, '-c', driver],
+        capture_output=True, text=True,
+        env={**os.environ, 'NUMBA_CACHE_DIR': nb_cache},
+    )
+    if proc.returncode != 0:
+        print(f"[{kind}] subprocess failed:")
+        print(proc.stdout)
+        print(proc.stderr)
+        return {'cold': None, 'hot_F': None, 'hot_J': None,
+                'nr': None, 'nr_ok': None, 'nr_its': None}
+    res = {}
+    for line in proc.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        key, val = parts
+        if key == 'COLD':     res['cold'] = float(eval(val))
+        elif key == 'HOT_F':  res['hot_F'] = float(eval(val))
+        elif key == 'HOT_J':  res['hot_J'] = float(eval(val))
+        elif key == 'NR':     res['nr'] = float(eval(val))
+        elif key == 'NR_OK':  res['nr_ok'] = bool(int(val))
+        elif key == 'NR_ITS': res['nr_its'] = int(val)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("Benchmarking LoopEqn vs for-loop polar power flow on case30")
+    print(f"Output root: {OUT_ROOT}\n")
+
+    print("--- for-loop (per-bus scalar Eqns; pf_mdl.py) ---")
+    r_loop_off = run_modeling_phases('forloop', build_polar)
+    print(f"  build={r_loop_off['build']:.3f}s  "
+          f"render={r_loop_off['render']:.3f}s  "
+          f"#njit={r_loop_off['njit_count']}  "
+          f"#eqn-families={r_loop_off['n_eqn_families']} "
+          f"(eqn_size={r_loop_off['eqn_size']})")
+    r_loop_off.update(run_subprocess_phases(
+        'forloop', r_loop_off['module_dir'], r_loop_off['mod_name']))
+
+    print("\n--- LoopEqn (symbolic Set/Sum template; pf_mdl_loopeqn.py) ---")
+    r_loop_on = run_modeling_phases('loopeqn', build_loopeqn)
+    print(f"  build={r_loop_on['build']:.3f}s  "
+          f"render={r_loop_on['render']:.3f}s  "
+          f"#njit={r_loop_on['njit_count']}  "
+          f"#eqn-families={r_loop_on['n_eqn_families']} "
+          f"(eqn_size={r_loop_on['eqn_size']})")
+    r_loop_on.update(run_subprocess_phases(
+        'loopeqn', r_loop_on['module_dir'], r_loop_on['mod_name']))
+
+    # --- Summary table ---
+    print()
+    print("=" * 74)
+    print(f"{'Phase':<32}{'for-loop':>14}{'LoopEqn':>14}{'ratio':>12}")
+    print("-" * 74)
+
+    def _fmt_s(x):
+        if x is None:
+            return f"{'FAIL':>12}"
+        if x < 0.01:
+            return f"{x*1000:>9.3f} ms"
+        return f"{x:>11.3f} s"
+
+    def _fmt_us(x):
+        return f"{x*1e6:>10.2f} us" if x is not None else f"{'FAIL':>12}"
+
+    def _fmt_int(x):
+        return f"{x:>12d}" if x is not None else f"{'FAIL':>12}"
+
+    def _ratio(a, b):
+        # report how much LoopEqn beats (or loses to) for-loop: a=for-loop, b=loopeqn
+        if a is None or b is None or b == 0:
+            return 'n/a'
+        return f"{a/b:>9.2f}x"
+
+    rows = [
+        ('1. Model + create_instance', r_loop_off['build'],          r_loop_on['build'],          'sec'),
+        ('2. Module render (jit=True)', r_loop_off['render'],         r_loop_on['render'],         'sec'),
+        ('3. @njit kernel count',       r_loop_off['njit_count'],     r_loop_on['njit_count'],     'int'),
+        ('4. Module cold import+JIT',   r_loop_off.get('cold'),       r_loop_on.get('cold'),       'sec'),
+        ('5. Module hot F (per call)',  r_loop_off.get('hot_F'),      r_loop_on.get('hot_F'),      'us'),
+        ('5. Module hot J (per call)',  r_loop_off.get('hot_J'),      r_loop_on.get('hot_J'),      'us'),
+        ('6. NR end-to-end',            r_loop_off.get('nr'),         r_loop_on.get('nr'),         'sec'),
+    ]
+    for label, a, b, unit in rows:
+        if unit == 'sec':
+            a_s, b_s = _fmt_s(a), _fmt_s(b)
+        elif unit == 'us':
+            a_s, b_s = _fmt_us(a), _fmt_us(b)
+        else:
+            a_s, b_s = _fmt_int(a), _fmt_int(b)
+        print(f"{label:<32}{a_s:>14}{b_s:>14}{_ratio(a, b):>12}")
+    print("=" * 74)
+    print("ratio = for-loop / LoopEqn  (>1 means LoopEqn is faster/smaller)\n")
+    print(f"#scalar equations (eqn_size): for-loop={r_loop_off['eqn_size']}, "
+          f"LoopEqn={r_loop_on['eqn_size']}")
+    print(f"#equation families: for-loop={r_loop_off['n_eqn_families']}, "
+          f"LoopEqn={r_loop_on['n_eqn_families']}")
+    if r_loop_off.get('nr_ok') is not None:
+        print(f"NR converged — for-loop: {r_loop_off['nr_ok']} "
+              f"({r_loop_off.get('nr_its')} steps); "
+              f"LoopEqn: {r_loop_on['nr_ok']} ({r_loop_on.get('nr_its')} steps)")
+    print(f"Artifacts at: {OUT_ROOT}")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/source/ae/pf/src/pf_mdl_loopeqn.py
+++ b/docs/source/ae/pf/src/pf_mdl_loopeqn.py
@@ -8,8 +8,9 @@ sub-function in the generated module is therefore either a LoopEqn
 kernel or the F_/J_ wrapper — there are no per-scalar
 ``inner_F<N>``'s emitted for the pin equations.
 
-This module is used by ``bench_pf_loopeqn_vs_legacy.py`` to measure the
-cold-cache module_printer compile-time delta.
+This module is used by ``bench_pf_loopeqn_vs_polar.py`` to measure the
+modelling / compile / runtime delta against the traditional for-loop
+formulation in ``pf_mdl.py``.
 """
 import os
 

--- a/docs/source/ae/pf/src/test_pf_jac.py
+++ b/docs/source/ae/pf/src/test_pf_jac.py
@@ -1,6 +1,9 @@
 import os
 import sys
 import shutil
+import importlib
+import tempfile
+import uuid
 
 import numpy as np
 from scipy.io import loadmat
@@ -311,3 +314,78 @@ def test_pf_matmul(datadir):
                                err_msg="Va mismatch between Mat_Mul module and polar inline")
 
     shutil.rmtree(test_folder_path)
+
+
+def _render_and_import(spf, y0, prefix):
+    """Render a model via ``module_printer(jit=True)`` into a temp dir and
+    import it. LoopEqn cannot run through the inline ``made_numerical``
+    path (issue #132), so the Numba-JIT module printer is the only route.
+    Returns ``(mdl, y, module_dir)``; the caller may best-effort remove
+    ``module_dir`` afterwards.
+    """
+    mod_name = f"{prefix}_{uuid.uuid4().hex[:8]}"
+    d = tempfile.mkdtemp(prefix="sz_pf_loopeqn_")
+    module_printer(spf, y0, mod_name, directory=d, jit=True).render()
+    sys.path.insert(0, d)
+    mod = importlib.import_module(mod_name)
+    return mod.mdl, mod.y, d
+
+
+def test_pf_loopeqn(datadir):
+    """LoopEqn polar power flow on case30 via the module printer.
+
+    Builds the exact model the cookbook chapter shows
+    (``pf_mdl_loopeqn.py``), renders it with ``module_printer(jit=True)``,
+    perturbs the flat start so Newton-Raphson actually iterates, and
+    cross-validates the recovered complex bus voltage against (a) the
+    MATPOWER reference solution and (b) the element-wise polar form
+    solved inline. The two formulations are algebraically identical, so
+    both comparisons must agree to Newton tolerance.
+    """
+    # Import the doc's LoopEqn model builder from this src directory.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from pf_mdl_loopeqn import build_loopeqn_pf_model
+
+    case = _load_case30(datadir)
+    V = case['V']
+    ref, pv, pq = case['ref'], case['pv'], case['pq']
+
+    m = build_loopeqn_pf_model(datadir=str(datadir))
+    spf, y0 = m.create_instance()
+
+    # 60 unknowns / 4 equation families (P_eqn, Q_eqn, Vm_pin, Va_pin).
+    assert spf.eqn_size == 2 * case['nb']
+    assert len(spf.EQNs) == 4
+
+    mdl, y, module_dir = _render_and_import(spf, y0, "pf_loopeqn")
+    try:
+        # Perturb the (already-converged) flat start so NR iterates.
+        y_run = type(y)(y.a, y.array.copy())
+        y_run['Vm_full'] = y_run['Vm_full'] + 0.03
+        y_run['Va_full'] = y_run['Va_full'] + 0.02
+        sol = nr_method(mdl, y_run)
+        assert sol.stats.succeed, "LoopEqn Newton-Raphson did not converge"
+
+        Vm_loop = np.asarray(sol.y['Vm_full']).ravel()
+        Va_loop = np.asarray(sol.y['Va_full']).ravel()
+        V_loop = Vm_loop * np.exp(1j * Va_loop)
+
+        # (a) vs. MATPOWER reference complex voltage.
+        np.testing.assert_allclose(V_loop, V, atol=1e-6, rtol=1e-6,
+                                   err_msg="LoopEqn solution disagrees with reference V")
+
+        # (b) vs. element-wise polar form solved inline.
+        m_polar = _build_polar_model(case)
+        spf_polar, y0_polar = m_polar.create_instance()
+        mdl_polar = made_numerical(spf_polar, y0_polar, sparse=True)
+        sol_polar = nr_method(mdl_polar, y0_polar)
+        Vm_polar = np.abs(V).copy()
+        Va_polar = np.angle(V).copy()
+        Va_polar[pv + pq] = sol_polar.y['Va']
+        Vm_polar[pq] = sol_polar.y['Vm']
+        V_polar = Vm_polar * np.exp(1j * Va_polar)
+
+        np.testing.assert_allclose(V_loop, V_polar, atol=1e-5, rtol=1e-5,
+                                   err_msg="LoopEqn module disagrees with polar inline")
+    finally:
+        shutil.rmtree(module_dir, ignore_errors=True)


### PR DESCRIPTION
## What

Adds a **LoopEqn vs. traditional for-loop** comparison to the power flow chapter (`docs/source/ae/pf/`), covering modelling / compilation / computation, and a regression test for the LoopEqn power flow model.

### Doc (`pf.md`)
Two new sections, inserted after the existing `Mat_Mul` comparison:

- **Compact polar power flow with `LoopEqn`** — introduces the `Set` / `Sum` / `LoopEqn` template that keeps the polar trigonometric formulation intact (unlike `Mat_Mul`, which switches to rectangular coordinates), with the `pf_mdl_loopeqn.py` model shown via `literalinclude`.
- **Performance comparison: `LoopEqn` vs. for-loop** — isolates the loop-expression cost (same polar coordinates, same `case30`).

| Axis | for-loop | LoopEqn | LoopEqn wins by |
| :-- | --: | --: | --: |
| Modelling `Model()→create_instance` | ≈ 1.4 s | ≈ 0.09 s | ~15× |
| Compilation render (`jit=True`) | ≈ 0.6 s | ≈ 0.014 s | ~43× |
| Compilation `@njit` kernels | 416 | 12 | ~35× |
| Compilation cold import + JIT | ≈ 45 s | ≈ 2.5 s | ~18× |
| Computation hot **F** | ≈ 1.05 µs | ≈ 2.35 µs | 0.45× *(loses)* |
| Computation hot **J** | ≈ 55 µs | ≈ 36 µs | ~1.5× |
| Computation NR end-to-end | ≈ 0.33 ms | ≈ 0.20 ms | ~1.6× |

Key finding: LoopEqn's hot **F** is slower (CSR-gather + loop overhead, same structural cost `Mat_Mul` pays on small networks), but its hot **J** is faster — the for-loop dispatches 361 per-non-zero Jacobian kernels while LoopEqn assembles the Jacobian through 4 vectorised kernels.

### Benchmark (`src/bench_pf_loopeqn_vs_polar.py`, new)
Head-to-head benchmark mirroring `bench_pf_matmul_vs_polar.py`. Module-path-only because `made_numerical` does not support LoopEqn (issue #132). Numbers measured on an Apple M4 (medians of three runs); re-runnable on any hardware.

### Test (`src/test_pf_jac.py`)
New `test_pf_loopeqn`: renders the LoopEqn model via `module_printer(jit=True)`, solves with Newton-Raphson from a perturbed flat start, and cross-validates the complex bus voltage against both the MATPOWER reference and the polar inline solution.

### Misc
- Fix the stale benchmark-script reference in `pf_mdl_loopeqn.py`'s docstring.

## Verification
- `pytest docs/source/ae/pf/src/test_pf_jac.py -v` → **4 passed** (incl. new `test_pf_loopeqn`).
- Sphinx HTML build of the chapter succeeds; all numbers/claims render.
- Every number was adversarially re-verified against a fresh benchmark run and the generated `num_func.py` kernel breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)